### PR TITLE
1.3.1 redesign error handling

### DIFF
--- a/CloverConnector/Classes/cloverconnector/CloverConnector.swift
+++ b/CloverConnector/Classes/cloverconnector/CloverConnector.swift
@@ -81,14 +81,17 @@ public class CloverConnector : NSObject, ICloverConnector {
             self.device = device
             device.initialize()
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "initializeConnection: The Clover Device is null, maybe the configuration is invalid"));
+            notifyListenersDeviceError(
+                CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected),
+                    code: 0,
+                    message: "initializeConnection: The Clover Device is null, maybe the configuration is invalid"))
         }
     }
     
     public func sale(_ saleRequest: SaleRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "sale: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "sale: The Clover Device is not ready"));
                 return;
             } else if(deviceObserver?.lastRequest != nil) {
                 // not using FinishCancel because that will clear the last request
@@ -117,7 +120,7 @@ public class CloverConnector : NSObject, ICloverConnector {
             saleAuth(saleRequest, suppressTipScreen: tos, requestInfo: TxStartRequestMessage.SALE_REQUEST)
         } else {
             deviceObserver!.onFinishCancel(false, result:ResultCode.ERROR, reason: "Device Connection Error", message: "In sale : The device is not connected.", requestInfo: TxStartRequestMessage.SALE_REQUEST);
-            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "initializeConnection: The Clover Device is null"));
+            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.communication, code: 0, message: "initializeConnection: The Clover Device is null"));
         }
     }
     
@@ -125,7 +128,7 @@ public class CloverConnector : NSObject, ICloverConnector {
         if let device = device {
             
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "auth: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "auth: The Clover Device is not ready"));
                 return;
             } else if(deviceObserver?.lastRequest != nil) {
                 // not using FinishCancel because that will clear the last request
@@ -156,7 +159,7 @@ public class CloverConnector : NSObject, ICloverConnector {
             saleAuth(authRequest, suppressTipScreen: true,requestInfo:TxStartRequestMessage.AUTH_REQUEST)
         } else {
             deviceObserver!.onFinishCancel(false, result:ResultCode.ERROR, reason: "Device Connection Error", message: "In auth : The device is not connected.", requestInfo: TxStartRequestMessage.AUTH_REQUEST);
-            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "initializeConnection: The Clover Device is null"));
+            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.communication, code: 0, message: "initializeConnection: The Clover Device is null"));
         }
     }
     
@@ -164,7 +167,7 @@ public class CloverConnector : NSObject, ICloverConnector {
         if let device = device {
             
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "tipAdjustAuth: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "tipAdjustAuth: The Clover Device is not ready"));
                 return;
             } else if(tipAdjustAuthRequest.tipAmount <= 0) {
                 deviceObserver!.onAuthTipAdjustedResponse(false, result: ResultCode.FAIL, reason: "Request validation error", message: "In PreAuth : PreAuthRequest - the request tipAmount cannot be zero. ");
@@ -178,7 +181,7 @@ public class CloverConnector : NSObject, ICloverConnector {
             
         } else {
             deviceObserver!.onAuthTipAdjustedResponse(false, result: ResultCode.ERROR, reason: "Device Connection Error", message: "In preAuth : The device is not connected.");
-            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "initializeConnection: The Clover Device is null"));
+            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.communication, code: 0, message: "initializeConnection: The Clover Device is null"));
         }
         
     }
@@ -187,7 +190,7 @@ public class CloverConnector : NSObject, ICloverConnector {
         if let device = device {
             
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "preAuth: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "preAuth: The Clover Device is not ready"));
                 return;
             } else if(preAuthRequest.amount <= 0) {
                 deviceObserver!.onFinishCancel(false, result:ResultCode.FAIL, reason: "Request validation error", message: "In PreAuth : PreAuthRequest - the request amount cannot be zero. ", requestInfo: TxStartRequestMessage.PREAUTH_REQUEST);
@@ -212,7 +215,7 @@ public class CloverConnector : NSObject, ICloverConnector {
             saleAuth(preAuthRequest, suppressTipScreen: true, requestInfo: TxStartRequestMessage.PREAUTH_REQUEST)
         } else {
             deviceObserver!.onFinishCancel(false, result:ResultCode.ERROR, reason: "Device Connection Error", message: "In preAuth : The device is not connected.", requestInfo: TxStartRequestMessage.PREAUTH_REQUEST);
-            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "initializeConnection: The Clover Device is null"));
+            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.communication, code: 0, message: "initializeConnection: The Clover Device is null"));
         }
         
     }
@@ -223,7 +226,7 @@ public class CloverConnector : NSObject, ICloverConnector {
             let tipAmount = capturePreAuthRequest.tipAmount ?? 0
             
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "capturePreAuth: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "capturePreAuth: The Clover Device is not ready"));
                 return;
             } else if (capturePreAuthRequest.amount < 0) {
                 deviceObserver!.onCapturePreAuthResponse(false, result:ResultCode.FAIL, reason: "Request validation error", message: "In capturePreAuth : The amount must be greater than 0")
@@ -237,7 +240,7 @@ public class CloverConnector : NSObject, ICloverConnector {
             device.doCaptureAuth(capturePreAuthRequest.paymentId, amount: capturePreAuthRequest.amount, tipAmount: tipAmount)
         } else {
             deviceObserver!.onCapturePreAuthResponse(false, result: ResultCode.ERROR, reason: "Device Connection Error", message: "In preAuth : The device is not connected.")
-            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "initializeConnection: The Clover Device is null"));
+            //notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.communication, code: 0, message: "initializeConnection: The Clover Device is null"));
         }
     }
     
@@ -333,24 +336,24 @@ public class CloverConnector : NSObject, ICloverConnector {
             
         } else {
             // no device, but shouldn't get here, as the callers should have made this check
-            broadcaster.notifyOnDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "Device is not connected."));
+            broadcaster.notifyOnDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "Device is not connected."));
         }
     }
 
     public func acceptSignature(_ signatureVerifyRequest: VerifySignatureRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "acceptSignature: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "acceptSignature: The Clover Device is not ready"));
                 return;
             } else if let payment = signatureVerifyRequest.payment {
                 device.doSignatureVerified(payment, verified: true)
             } else {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "In acceptSignature: The payment is required"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.missingPayment), code: 0, message: "In acceptSignature: The payment is required"));
                 return
             }
             
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "In acceptSignautre: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "In acceptSignautre: The Clover Device is null"));
         }
         
     }
@@ -358,24 +361,24 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func rejectSignature(_ signatureVerifyRequest: VerifySignatureRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "rejectSignature: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "rejectSignature: The Clover Device is not ready"));
                 return;
             } else if let payment = signatureVerifyRequest.payment {
                 device.doSignatureVerified(payment, verified: false)
             } else {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "In rejectSignature: The payment is required"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.missingPayment), code: 0, message: "In rejectSignature: The payment is required"));
                 return
             }
             
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "In rejectSignature: The Clover Device is not connected"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "In rejectSignature: The Clover Device is not connected"));
         }
     }
     
     public func refundPayment(_ refundPaymentRequest: RefundPaymentRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "refundPayment: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "refundPayment: The Clover Device is not ready"));
                 return;
             } else if(!refundPaymentRequest.fullRefund && refundPaymentRequest.amount ?? 0 <= 0) {
                 let prr = RefundPaymentResponse(success:false, result:ResultCode.FAIL)
@@ -407,7 +410,7 @@ public class CloverConnector : NSObject, ICloverConnector {
         deviceObserver!.lastRequest = manualRefundRequest
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "manualRefund: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "manualRefund: The Clover Device is not ready"));
                 return;
             } else if manualRefundRequest.amount <= 0 {
                 deviceObserver!.onFinishCancel(false, result: ResultCode.FAIL, reason: "Invalid argument", message: "The amount must be greater than 0", requestInfo: TxStartRequestMessage.CREDIT_REQUEST)
@@ -456,7 +459,7 @@ public class CloverConnector : NSObject, ICloverConnector {
         
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "voidPayment: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "voidPayment: The Clover Device is not ready"));
                 return;
             }
             let payment = CLVModels.Payments.Payment()
@@ -478,7 +481,7 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func vaultCard(_ vaultCardRequest: VaultCardRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "vaultCard: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "vaultCard: The Clover Device is not ready"));
                 return;
             } else if merchantInfo.supportsVaultCards {
                 device.doVaultCard(vaultCardRequest.cardEntryMethods ?? self.cardEntryMethods)
@@ -495,12 +498,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func closeout(_ closeoutRequest: CloseoutRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "closeout: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "closeout: The Clover Device is not ready"));
                 return;
             }
             device.doCloseout(closeoutRequest.allowOpenTabs, batchId: closeoutRequest.batchId)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "In Closeout: The Clover Device is not connected"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "In Closeout: The Clover Device is not connected"));
         }
         
     }
@@ -508,12 +511,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func displayPaymentReceiptOptions(_ orderId:String, paymentId:String) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "displayPaymentReceiptOptions: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "displayPaymentReceiptOptions: The Clover Device is not ready"));
                 return;
             }
             device.doShowPaymentReceiptScreen(orderId, paymentId:paymentId);
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "In showPaymentReceiptOptions: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "In showPaymentReceiptOptions: The Clover Device is null"));
         }
     
     }
@@ -522,13 +525,13 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func showMessage(_ message: String) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showMessage: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "showMessage: The Clover Device is not ready"));
                 return;
             }
             device.doTerminalMessage(message)
             
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showMessage: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "showMessage: The Clover Device is null"));
         }
 
     }
@@ -537,12 +540,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func printText(_ lines: [String]) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "printText: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "printText: The Clover Device is not ready"));
                 return;
             }
             device.doPrintText(lines)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "printText: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "printText: The Clover Device is null"));
         }
         
     }
@@ -551,24 +554,24 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func printImageFromURL(_ url:String) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "printImageFromURL: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "printImageFromURL: The Clover Device is not ready"));
                 return;
             }
             device.doPrintImage(url)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "printImageFromURL: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "printImageFromURL: The Clover Device is null"));
         }
     }
     
     public func printImage(_ image: UIImage) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "printImage: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "printImage: The Clover Device is not ready"));
                 return;
             }
             device.doPrintImage(image);
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "printImage: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "printImage: The Clover Device is null"));
         }
 
     }
@@ -577,12 +580,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func cancel() {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "cancel: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "cancel: The Clover Device is not ready"));
                 return;
             }
             device.doKeyPress(KeyPress.esc)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "cancel: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "cancel: The Clover Device is null"));
         }
 
     }
@@ -591,12 +594,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func openCashDrawer(_ reason:String) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "openCashDrawer: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "openCashDrawer: The Clover Device is not ready"));
                 return;
             }
             device.doOpenCashDrawer(reason)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "openCashDrawer: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "openCashDrawer: The Clover Device is null"));
         }
 
         
@@ -607,12 +610,12 @@ public class CloverConnector : NSObject, ICloverConnector {
         deviceObserver?.lastRequest = nil
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "resetDevice: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "resetDevice: The Clover Device is not ready"));
                 return;
             }
             device.doBreak()
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "resetDevice: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "resetDevice: The Clover Device is null"));
         }
     }
     
@@ -620,12 +623,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func showWelcomeScreen() {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showWelcomeScreen: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "showWelcomeScreen: The Clover Device is not ready"));
                 return;
             }
             device.doShowWelcomeScreen()
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showWelcomeScreen: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "showWelcomeScreen: The Clover Device is null"));
         }
 
     }
@@ -634,12 +637,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func showThankYouScreen() {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showThankYouScreen: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "showThankYouScreen: The Clover Device is not ready"));
                 return;
             }
             device.doShowThankYouScreen()
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showThankYouScreen: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "showThankYouScreen: The Clover Device is null"));
         }
 
     }
@@ -648,12 +651,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func showDisplayOrder(_ order: DisplayOrder) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showDisplayOrder: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "showDisplayOrder: The Clover Device is not ready"));
                 return;
             }
             device.doOrderUpdate(order, orderOperation: nil)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "showDisplayOrder: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "showDisplayOrder: The Clover Device is null"));
         }
 
     }
@@ -662,12 +665,12 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func removeDisplayOrder(_ order: DisplayOrder) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "removeDisplayOrder: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "removeDisplayOrder: The Clover Device is not ready"));
                 return;
             }
             device.doOrderUpdate(DisplayOrder(), orderOperation: nil)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "removeDisplayOrder: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "removeDisplayOrder: The Clover Device is null"));
         }
     }
     
@@ -676,15 +679,15 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func invokeInputOption(_ inputOption:InputOption) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "invokeInputOption: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "invokeInputOption: The Clover Device is not ready"));
                 return;
             } else if let kp = inputOption.keyPress {
                 device.doKeyPress(kp);
             } else {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.VALIDATION_ERROR, code: 0, message: "invokeInputOption: the keyPress is required"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .validation(.keyPressRequired), code: 0, message: "invokeInputOption: the keyPress is required"));
             }
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "invokeInputOption: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "invokeInputOption: The Clover Device is null"));
         }
 
     }
@@ -696,7 +699,7 @@ public class CloverConnector : NSObject, ICloverConnector {
     public func readCardData( _ request:ReadCardDataRequest ) -> Void {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "readCardData: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "readCardData: The Clover Device is not ready"));
                 return;
             }
             let builder:PayIntent.Builder = PayIntent.Builder(amount: 0, externalId: "\(arc4random())")
@@ -709,91 +712,91 @@ public class CloverConnector : NSObject, ICloverConnector {
             
             device.doReadCardData(builder.build())
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "readCardData: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "readCardData: The Clover Device is null"));
         }
     }
     
     public func acceptPayment( _ payment:CLVModels.Payments.Payment ) -> Void {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "readCardData: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "readCardData: The Clover Device is not ready"));
                 return;
             }
             device.doAcceptPayment(payment)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "acceptPayment: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "acceptPayment: The Clover Device is null"));
         }
     }
     
     public func rejectPayment( _ payment:CLVModels.Payments.Payment, challenge:Challenge ) -> Void {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "rejectPayment: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "rejectPayment: The Clover Device is not ready"));
                 return;
             }
             device.doRejectPayment(payment, challenge: challenge)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "rejectPayment: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "rejectPayment: The Clover Device is null"));
         }
     }
     
     public func retrievePendingPayments() -> Void {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "retrievePendingPayments: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "retrievePendingPayments: The Clover Device is not ready"));
                 return;
             }
             device.doRetrievePendingPayments();
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "retrievePendingPayments: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "retrievePendingPayments: The Clover Device is null"));
         }
     }
     
     public func startCustomActivity(request: CustomActivityRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "startCustomActivity: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "startCustomActivity: The Clover Device is not ready"));
                 return;
             }
             device.doStartActivity(action: request.action, payload: request.payload, nonBlocking: request.nonBlocking ?? false)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "startCustomActivity: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "startCustomActivity: The Clover Device is null"));
         }
     }
     
     public func sendMessageToActivity(request: MessageToActivity) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "sendMessageToActivity: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "sendMessageToActivity: The Clover Device is not ready"));
                 return
             }
             device.doSendMessageToActivity(action: request.action, payload: request.payload)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "sendMessageToActivity: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "sendMessageToActivity: The Clover Device is null"));
         }
     }
-    
+
     public func retrievePayment(_ request: RetrievePaymentRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "retrievePayment: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "retrievePayment: The Clover Device is not ready"));
                 return;
             }
             device.doRetrievePayment(request.externalPayentId)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "retrievePayment: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "retrievePayment: The Clover Device is null"));
         }
     }
     
     public func retrieveDeviceStatus(_ request: RetrieveDeviceStatusRequest) {
         if let device = device {
             if !isReady {
-                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "retrieveDeviceStatus: The Clover Device is not ready"));
+                notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.deviceNotReady), code: 0, message: "retrieveDeviceStatus: The Clover Device is not ready"));
                 return;
             }
             device.doRetrieveDeviceStatus(request.sendLastMessage)
         } else {
-            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: CloverDeviceErrorType.COMMUNICATION_ERROR, code: 0, message: "retrieveDeviceStatus: The Clover Device is null"));
+            notifyListenersDeviceError(CloverDeviceErrorEvent(errorType: .communication(.noReaderConnected), code: 0, message: "retrieveDeviceStatus: The Clover Device is null"));
         }
     }
     
@@ -843,9 +846,12 @@ public class CloverConnector : NSObject, ICloverConnector {
             cloverConnector.broadcaster.notifyOnConnect()
         }
         
-        func onDeviceDisconnected(_ device: CloverDevice) {
+        func onDeviceDisconnected(_ device: CloverDevice, errorEvent: CloverDeviceErrorEvent?) {
             cloverConnector.isReady = false
             cloverConnector.broadcaster.notifyOnDisconnect()
+            if let errorEvent = errorEvent {
+                cloverConnector.broadcaster.notifyOnDeviceError(errorEvent)
+            }
         }
         
         func onDeviceReady(_ device: CloverDevice, discoveryResponseMessage: DiscoveryResponseMessage) {

--- a/CloverConnector/Classes/cloverconnector/CloverConnector.swift
+++ b/CloverConnector/Classes/cloverconnector/CloverConnector.swift
@@ -848,7 +848,7 @@ public class CloverConnector : NSObject, ICloverConnector {
         
         func onDeviceDisconnected(_ device: CloverDevice, errorEvent: CloverDeviceErrorEvent?) {
             cloverConnector.isReady = false
-            cloverConnector.broadcaster.notifyOnDisconnect()
+            cloverConnector.broadcaster.notifyOnDisconnect(withErrorEvent: errorEvent)
             if let errorEvent = errorEvent {
                 cloverConnector.broadcaster.notifyOnDeviceError(errorEvent)
             }

--- a/CloverConnector/Classes/cloverconnector/CloverConnectorBroadcaster.swift
+++ b/CloverConnector/Classes/cloverconnector/CloverConnectorBroadcaster.swift
@@ -129,10 +129,10 @@ public class CloverConnectorBroadcaster {
         }
     }
     
-    public func notifyOnDisconnect() {
+    public func notifyOnDisconnect(withErrorEvent event: CloverDeviceErrorEvent?) {
         for listener in listeners {
             if let listener = listener as? ICloverConnectorListener {
-                listener.onDeviceDisconnected()
+                listener.onDeviceDisconnected(withErrorEvent: event)
             }
         }
     }

--- a/CloverConnector/Classes/cloverconnector/CloverConnectorBroadcaster.swift
+++ b/CloverConnector/Classes/cloverconnector/CloverConnectorBroadcaster.swift
@@ -31,8 +31,6 @@ public class CloverConnectorBroadcaster {
         }
     }
     
-    
-    
     public func notifyOnPaymentRefundResponse(_ refundPaymentResponse:RefundPaymentResponse) {
         for listener in listeners {
             if let listener = listener as? ICloverConnectorListener {

--- a/CloverConnector/Classes/cloverconnector/CloverDeviceObserver.swift
+++ b/CloverConnector/Classes/cloverconnector/CloverDeviceObserver.swift
@@ -60,7 +60,7 @@ protocol CloverDeviceObserver:AnyObject {
     
     func onTxStartResponse(_ result:TxStartResponseResult, externalId:String, requestInfo: String?)
     
-    func onDeviceDisconnected( _ device:CloverDevice)
+    func onDeviceDisconnected( _ device:CloverDevice, errorEvent: CloverDeviceErrorEvent?)
     func onDeviceConnected(_ device:CloverDevice)
     func onDeviceReady(_ device:CloverDevice, discoveryResponseMessage:DiscoveryResponseMessage)
     
@@ -124,7 +124,7 @@ public class DefaultCloverDeviceObserver : CloverDeviceObserver {
     
     func onTxStartResponse(_ result:TxStartResponseResult, externalId:String, requestInfo: String?){}
     
-    func onDeviceDisconnected( _ device:CloverDevice){}
+    func onDeviceDisconnected( _ device:CloverDevice, errorEvent: CloverDeviceErrorEvent?){}
     func onDeviceConnected(_ device:CloverDevice){}
     func onDeviceReady(_ device:CloverDevice, discoveryResponseMessage:DiscoveryResponseMessage){}
     

--- a/CloverConnector/Classes/cloverconnector/CloverTransport.swift
+++ b/CloverConnector/Classes/cloverconnector/CloverTransport.swift
@@ -36,7 +36,7 @@ public class CloverTransport : NSObject {
     func onDeviceDisconnected() {
         ready = false
         for obs in observers {
-            (obs as! CloverTransportObserver).onDeviceDisconnected(self)
+            (obs as! CloverTransportObserver).onDeviceDisconnected(self, error: nil)
         }
     }
     

--- a/CloverConnector/Classes/cloverconnector/CloverTransportObserver.swift
+++ b/CloverConnector/Classes/cloverconnector/CloverTransportObserver.swift
@@ -23,7 +23,7 @@ protocol CloverTransportObserver : AnyObject{
     /// Device is not there anymore
     /// </summary>
     /// <param name="transport"></param>
-    func onDeviceDisconnected(_ transport:CloverTransport)
+    func onDeviceDisconnected(_ transport:CloverTransport, error: NSError?)
     
     func onMessage(_ message:String)
 }

--- a/CloverConnector/Classes/cloverconnector/DefaultCloverConnectorListener.swift
+++ b/CloverConnector/Classes/cloverconnector/DefaultCloverConnectorListener.swift
@@ -124,7 +124,7 @@ public class DefaultCloverConnectorListener : NSObject, ICloverConnectorListener
     /*
      * called when the device is disconnected, or not responding
      */
-    public func  onDeviceDisconnected () -> Void {}
+    public func  onDeviceDisconnected(withErrorEvent event: CloverDeviceErrorEvent?) -> Void {}
     
     /*
      * callbacks if disablePrinting is enabled on the request

--- a/CloverConnector/Classes/cloverconnector/ICloverConnectorListener.swift
+++ b/CloverConnector/Classes/cloverconnector/ICloverConnectorListener.swift
@@ -105,7 +105,7 @@ public protocol ICloverConnectorListener : AnyObject {
     /*
      * called when the device is disconnected, or not responding
      */
-    func  onDeviceDisconnected () -> Void
+    func  onDeviceDisconnected(withErrorEvent event: CloverDeviceErrorEvent?) -> Void
     
     /**
      * Called when the Clover device requires confirmation for a payment

--- a/CloverConnector/Classes/cloverconnector/WebSocketCloverTransport.swift
+++ b/CloverConnector/Classes/cloverconnector/WebSocketCloverTransport.swift
@@ -39,7 +39,6 @@ class WebSocketCloverTransport: CloverTransport {
         debugPrint("deinit WebSocketCloverTransport")
     }
 
-    
     init?(endpointURL: String, posName:String, serialNumber:String, pairingAuthToken: String?, pairingDeviceConfiguration:PairingDeviceConfiguration, pongTimeout pt:Int? = 15, pingFrequency pf:Int? = 3, reconnectDelay rd:Int? = 2, reportConnectionProblemAfter rt:Int? = 20) {
 
         df.dateFormat = "y-MM-dd H:m:ss.SSSS"
@@ -92,12 +91,14 @@ class WebSocketCloverTransport: CloverTransport {
                 self?.schedulePing()
                 self?.sendPairingRequest()
             }
-            socket.onDisconnect = { [weak self] (error: NSError?) in
+            socket.onDisconnect = { [weak self] error in
                 guard let strongSelf = self else { return }
                 print("websocket is disconnected: \(error?.localizedDescription)")
                 //print(error?.userInfo[NSUnderlyingErrorKey])
                 for obs in strongSelf.observers {
-                    (obs as! CloverTransportObserver).onDeviceDisconnected(strongSelf)
+                    (obs as! CloverTransportObserver)
+                        .onDeviceDisconnected(strongSelf,
+                                              error: error)
                 }
                 strongSelf.disconnectTimer?.invalidate()
                 strongSelf.reportDisconnectTimer?.invalidate()

--- a/Example/CloverConnector/CloverConnectorListener.swift
+++ b/Example/CloverConnector/CloverConnectorListener.swift
@@ -523,7 +523,7 @@ public class CloverConnectorListener : NSObject, ICloverConnectorListener, UIAle
         ready = false // the device is connected, but not ready to communicate
     }
     
-    public func onDeviceDisconnected() {
+    public func onDeviceDisconnected(withErrorEvent event: CloverDeviceErrorEvent?) {
         if ready {
             showMessage("Disconnected", duration: 2)
         }

--- a/Example/CloverConnector/CloverConnectorListener.swift
+++ b/Example/CloverConnector/CloverConnectorListener.swift
@@ -515,16 +515,8 @@ public class CloverConnectorListener : NSObject, ICloverConnectorListener, UIAle
     }
     
     
-    public func onDeviceError(_ deviceErrorEvent: CloverDeviceErrorEvent) {
-        dispatch_async(dispatch_get_main_queue()){
-            let uiac = UIAlertController(title: deviceErrorEvent.errorType.rawValue, message: deviceErrorEvent.message, preferredStyle: .Alert)
-            self.uiAlertController = uiac
-            self.viewController?.presentViewController(uiac, animated: false, completion: {})
-            self.uiAlertController?.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: {
-                (aa:UIAlertAction) in
-                self.uiAlertController?.dismissViewControllerAnimated(false, completion: {})
-            }))
-        }
+    public func onDeviceError(deviceErrorEvent: CloverDeviceErrorEvent) {
+        print(deviceErrorEvent, deviceErrorEvent.message, deviceErrorEvent.error)
     }
 
     public func onDeviceConnected() {

--- a/Example/CloverConnector/TabController.swift
+++ b/Example/CloverConnector/TabController.swift
@@ -41,7 +41,7 @@ class TabBarController : UITabBarController {
                 self.barController.tabBar.backgroundColor = UIColor.yellowColor()
             }
         }
-        override func onDeviceDisconnected() {
+        override func onDeviceDisconnected(withErrorEvent event: CloverDeviceErrorEvent?) {
             dispatch_async(dispatch_get_main_queue()) {
                 self.barController.tabBar.backgroundColor = UIColor.redColor()
             }


### PR DESCRIPTION
This PR aims at making the error handling in the Clover Connector SDK more robust. The `CloverDeviceErrorEvent` was left alone as a carrier for the error as there may be plans later for obj-c interop. Instead of overhauling the error event, the `eventType` was replaced with a more comprehensive `error: CloverDeviceError`. 

This gives us a strongly typed error handling system rather than the stringly typed version, previously used, where the event's `message` would have to be parsed to identify the error. 

Additionally, the errors are more comprehensive, now including errors around `SSL handshake failures` such as `invalidSSLCertificateChain` and `expiredCerts`. I've also added a few common POSIX errors that seem to have come up while testing such as connection refused and no network.

Finally I've also added an error to account for socket write timeouts.