### PR TITLE
Fix [RetrievePaymentResponse] always failed

### DIFF
--- a/CloverConnector/Classes/remotepaylib/RetrievePaymentResponseMessage.swift
+++ b/CloverConnector/Classes/remotepaylib/RetrievePaymentResponseMessage.swift
@@ -33,5 +33,6 @@ public class RetrievePaymentResponseMessage:Message {
         externalPaymentId <- map["externalPaymentId"]
         payment <- (map["payment"], Message.paymentTransform)
         reason <- map["reason"]
+        result <- map["status"]
     }
 }


### PR DESCRIPTION
Issue:
- Attribute [success] in RetrievePaymentResponse is always false
- Attribute [result] in RetrievePaymentResponse is always FAIL

Cause of the issue:
- Missing mapping [result] in RetrievePaymentResponseMessage

How to fix:
- Mapping [status] to [result] in RetrievePaymentResponseMessage